### PR TITLE
typo localstorage name raidvisibility

### DIFF
--- a/src/app/components/CharacterGrid.tsx
+++ b/src/app/components/CharacterGrid.tsx
@@ -206,7 +206,7 @@ const CharacterGrid: React.FC<GoldGridProps> = ({ raids }) => {
     const label = Object.keys(raidGroups)[labelIndex];
     const updatedVisibility = raidVisibility.map((visible, i) => (i === labelIndex ? !visible : visible));
     setRaidVisibility(updatedVisibility);
-    localStorage.setItem('raidVisbility2', JSON.stringify(updatedVisibility));
+    localStorage.setItem('raidVisibility2', JSON.stringify(updatedVisibility));
 
     // If the raid is being hidden, set all associated check states to false
     if (!updatedVisibility[labelIndex]) {


### PR DESCRIPTION
there is a typo in the localStorage naming for saving the raid visiblity
its saved / loaded with different names and therefore not correctly preserved